### PR TITLE
Ignore *.sig signatures

### DIFF
--- a/ecleankernel/layout/std.py
+++ b/ecleankernel/layout/std.py
@@ -70,7 +70,8 @@ class StdLayout(ModuleDirLayout):
             pass
         else:
             for fn in diter:
-                if fn.startswith('.'):
+                # skip hidden and GRUB signature files
+                if fn.startswith('.') or fn.endswith('.sig'):
                     continue
                 path = boot_directory / fn
                 if path.is_symlink() or not path.is_file():


### PR DESCRIPTION
A tiny patch to ignore signatures of files in /boot. Those may be used by [GRUB2](https://www.gnu.org/software/grub/manual/grub/html_node/Using-digital-signatures.html).