### PR TITLE
Add support for non-bzImage kernels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,12 @@ no_implicit_optional = True
 
 [mypy-pymountboot.*]
 ignore_missing_imports = True
+
+[mypy-lz4.*]
+ignore_missing_imports = True
+
+[mypy-lzo.*]
+ignore_missing_imports = True
+
+[mypy-zstandard.*]
+ignore_missing_imports = True

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -2,14 +2,18 @@
 # (c) 2020 Michał Górny <mgorny@gentoo.org>
 # Released under the terms of the 2-clause BSD license.
 
+import gzip
+import hashlib
 import os
 import tempfile
 import unittest
 
+from importlib import util
 from pathlib import Path
 
 from ecleankernel.file import (KernelImage, ModuleDirectory,
-                               UnrecognizedKernelError)
+                               UnrecognizedKernelError,
+                               MissingDecompressorError)
 
 
 def write_bzImage(path: Path,
@@ -24,6 +28,32 @@ def write_bzImage(path: Path,
         f.write(version_line)
 
 
+def write_raw(path: Path,
+              version_line: bytes
+              ) -> None:
+    """Write a raw kernel binary at `path`, with `version_line`"""
+    with open(path, 'wb') as f:
+        f.write(0x210 * b'\0')
+        f.write(version_line)
+
+
+def write_compress(path: Path,
+                   version_line: bytes
+                   ) -> None:
+    """Write a gzip compressed raw kernel binary at `path`,
+    with `version_line`"""
+    with gzip.open(path, 'wb') as f:
+        # gzip would compress a string of 0s below 0x200,
+        # so we fill in some incompressible gibberish
+        s = b''
+        for i in range(1, 0xff):
+            m = hashlib.sha1()
+            m.update(i.to_bytes(1, 'little'))
+            s += m.digest()
+        f.write(s)
+        f.write(version_line)
+
+
 class KernelImageTests(unittest.TestCase):
     def setUp(self) -> None:
         self.td = tempfile.TemporaryDirectory()
@@ -31,9 +61,23 @@ class KernelImageTests(unittest.TestCase):
     def tearDown(self) -> None:
         self.td.cleanup()
 
-    def test_read_internal_version(self) -> None:
+    def test_read_internal_version_bz(self) -> None:
         path = Path(self.td.name) / 'vmlinuz'
         write_bzImage(path, b'1.2.3 built on test')
+        self.assertEqual(
+            KernelImage(path).read_internal_version(),
+            '1.2.3')
+
+    def test_read_internal_version_raw(self) -> None:
+        path = Path(self.td.name) / 'vmlinuz'
+        write_raw(path, b'Linux version 1.2.3 built on test')
+        self.assertEqual(
+            KernelImage(path).read_internal_version(),
+            '1.2.3')
+
+    def test_read_internal_version_compress(self) -> None:
+        path = Path(self.td.name) / 'vmlinuz'
+        write_compress(path, b'Linux version 1.2.3 built on test')
         self.assertEqual(
             KernelImage(path).read_internal_version(),
             '1.2.3')
@@ -49,6 +93,36 @@ class KernelImageTests(unittest.TestCase):
         path = Path(self.td.name) / 'vmlinuz'
         with open(path, 'wb') as f:
             f.write(0x210 * b'\0')
+        with self.assertRaises(UnrecognizedKernelError):
+            KernelImage(path).read_internal_version()
+
+    def test_bad_file_magic(self) -> None:
+        path = Path(self.td.name) / 'vmlinuz'
+        with open(path, 'w') as f:
+            f.write('Hello World')
+        with self.assertRaises(UnrecognizedKernelError):
+            KernelImage(path).read_internal_version()
+
+    def test_missing_decompressor(self) -> None:
+        if util.find_spec('lzo'):
+            self.skipTest('the missing decompressor is installed')
+        path = Path(self.td.name) / 'vmlinuz'
+        with open(path, 'wb') as f:
+            f.write(b'\x89\x4c\x5a\x4f\x00\x0d\x0a\x1a\x0a')
+            f.write(0x210 * b'\0')
+        with self.assertRaises(MissingDecompressorError):
+            KernelImage(path).read_internal_version()
+
+    def test_overflow_ver_string_bz(self) -> None:
+        path = Path(self.td.name) / 'vmlinuz'
+        path = Path(self.td.name) / 'vmlinuz'
+        write_bzImage(path, b'1.2.3' + 0xffff * b'\0')
+        with self.assertRaises(UnrecognizedKernelError):
+            KernelImage(path).read_internal_version()
+
+    def test_overflow_ver_string_raw(self) -> None:
+        path = Path(self.td.name) / 'vmlinuz'
+        write_raw(path, b'Linux version 1.2.3' + 0xffff * b'\0')
         with self.assertRaises(UnrecognizedKernelError):
             KernelImage(path).read_internal_version()
 

--- a/test/test_process.py
+++ b/test/test_process.py
@@ -35,8 +35,8 @@ class KernelRemovalTests(unittest.TestCase):
 
         self.td = tempfile.TemporaryDirectory()
         td = Path(self.td.name)
-        write_bzImage(td / 'kernel.old', b'old')
-        write_bzImage(td / 'kernel.new', b'new')
+        write_bzImage(td / 'kernel.old', b'old built on test')
+        write_bzImage(td / 'kernel.new', b'new built on test')
         with open(td / 'config-stray', 'w'):
             pass
         with open(td / 'initrd-stray.img', 'w'):


### PR DESCRIPTION
Many non-x86 platforms do not use / support the bzImage format, but use raw binaries instead.
Sadly there is no metadata header that contains the version string, nor is there any standardized address within the image (that I'm aware of).
Furthermore, on these platforms the kernel image doesn't decompress itself but is compressed as a whole, with the task of decompression being left to the bootloader.

This pull adds support for uncompressed and compressed (currently gzip, bzip2, xz, lzma, lz4, lzo and zstd) raw kernel images.
This is implemented by parsing the raw file for the string "Linux version $VERSION ...", which is the greeter line you see on boot.

For this the following new dependencies are needed:
sys-apps/file[python]
dev-python/lz4
dev-python/python-lzo
dev-python/zstandard