### PR TITLE
fix zstd decompressor since initrd has no content size header

### DIFF
--- a/ecleankernel/file.py
+++ b/ecleankernel/file.py
@@ -123,7 +123,14 @@ class KernelImage(GenericFile):
                     # Technically a redundant import, this is just
                     # to make your IDE happy :)
                     import zstandard
-                    return zstandard.ZstdDecompressor().decompress(f.read())
+                    reader = zstandard.ZstdDecompressor().stream_reader(f)
+                    decomp = b''
+                    while True:
+                        chunk = reader.read(1024*1024)
+                        if not chunk:
+                            break
+                        decomp += chunk
+                    return decomp
                 else:
                     return getattr(mod, 'decompress')(f.read())
         return f.read()


### PR DESCRIPTION
It seems the kernel image and/or initrd may not include content size when compressed with zstd - switch to the zstd stream reader and read in chunks of 1MB until EOF

See the section above https://pypi.org/project/zstandard/ - Stream Reader API for details