### PR TITLE
blspec: Add /boot/efi and /efi as potential EFI directories

### DIFF
--- a/ecleankernel/layout/blspec.py
+++ b/ecleankernel/layout/blspec.py
@@ -28,7 +28,7 @@ class BlSpecLayout(ModuleDirLayout):
     """
 
     name = 'blspec'
-    potential_dirs = ('boot/EFI', 'boot')
+    potential_dirs = ('boot/EFI', 'boot/efi', 'boot', 'efi')
 
     name_map = {
         'initrd': KernelFileType.INITRAMFS,


### PR DESCRIPTION
According to https://systemd.io/BOOT_LOADER_SPECIFICATION/ the
placeholder file system $BOOT should be mounted on /boot or
/efi. Additional locations like /boot/efi might also be supported.

This is also what systemd's /usr/bin/kernel-install bash script
currently supports.

Bug: https://github.com/mgorny/eclean-kernel/issues/2
Signed-off-by: Florian Schmaus <flo@geekplace.eu>