### PR TITLE
Fix --no-mount logic inversion

### DIFF
--- a/ecleankernel/__main__.py
+++ b/ecleankernel/__main__.py
@@ -124,7 +124,7 @@ def main(argv: typing.List[str]) -> int:
                        action='store_true',
                        help='Enable debugging output')
     group.add_argument('-M', '--no-mount',
-                       action='store_false',
+                       action='store_true',
                        help='Disable (re-)mounting /boot if necessary')
     group.add_argument('--no-bootloader-update',
                        action='store_true',


### PR DESCRIPTION
The `--no-mount` argument uses `store_false` which implies `True` as the
default, making `--no-mount` the default behavior when the option isn't
specified and when it _is_ specified, it actually means the inverse.
This doesn't seem to be the actual intent (otherwise the option should be
renamed to `--mount`).