### PR TITLE
Fix LZMA Decompress Error

### DIFF
--- a/ecleankernel/file.py
+++ b/ecleankernel/file.py
@@ -11,7 +11,6 @@ import struct
 from lzma import LZMADecompressor, LZMAError
 
 from pathlib import Path
-from typing import List
 
 
 @enum.unique
@@ -99,25 +98,12 @@ class KernelImage(GenericFile):
         self.internal_version = self.read_internal_version()
 
     def decompress_lzma(self, data: bytes) -> bytes:
-        results: List[bytes] = []
-        while True:
-            decomp = LZMADecompressor()
-            try:
-                res = decomp.decompress(data)
-            except LZMAError:
-                if results:
-                    break  # Leftover data is not a valid LZMA/XZ stream;
-                    # ignore it.
-                else:
-                    raise  # Error on the first iteration; bail out.
-            results.append(res)
-            data = decomp.unused_data
-            if not data:
-                break
-            if not decomp.eof:
-                raise LZMAError("Compressed data ended before the "
-                                "end-of-stream marker was reached")
-        return b"".join(results)
+        decomp = LZMADecompressor()
+        try:
+            res = decomp.decompress(data)
+        except LZMAError:
+            raise
+        return res
 
     def decompress_raw(self) -> bytes:
         f = open(self.path, 'rb')

--- a/ecleankernel/file.py
+++ b/ecleankernel/file.py
@@ -101,7 +101,7 @@ class KernelImage(GenericFile):
     def decompress_lzma(self, data: bytes) -> bytes:
         results: List[bytes] = []
         while True:
-            decomp = LZMADecompressor(FORMAT_AUTO, None, None)
+            decomp = LZMADecompressor()
             try:
                 res = decomp.decompress(data)
             except LZMAError:

--- a/ecleankernel/file.py
+++ b/ecleankernel/file.py
@@ -8,7 +8,7 @@ import importlib
 import os
 import shutil
 import struct
-from lzma import LZMADecompressor, FORMAT_AUTO, LZMAError
+from lzma import LZMADecompressor, LZMAError
 
 from pathlib import Path
 from typing import List


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix error `LZMAError('Compressed data ended before the end-of-stream marker was reached')` when trying to list kernel (`eclean-kernel -l`) or remove kernel.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/mgorny/eclean-kernel/issues/29

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix error in python lzma decompress function so eclean-kernel can list and remove kernel.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I execute it and I can remove my old kernels.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
