### PR TITLE
Add support for BIOS/extlinux setups

### DIFF
--- a/ecleankernel/__main__.py
+++ b/ecleankernel/__main__.py
@@ -22,6 +22,7 @@ from ecleankernel.process import get_removal_list, get_removable_files
 from ecleankernel.bootloader.grub import GRUB
 from ecleankernel.bootloader.grub2 import GRUB2
 from ecleankernel.bootloader.lilo import LILO
+from ecleankernel.bootloader.extlinux import EXTLINUX
 from ecleankernel.bootloader.yaboot import Yaboot
 from ecleankernel.bootloader.symlinks import Symlinks
 from ecleankernel.layout.blspec import BlSpecLayout
@@ -63,7 +64,7 @@ as root, or preferably mount /boot before using it.'''
 def main(argv: typing.List[str]) -> int:
     kernel_parts = [x.value for x in KernelFileType.__members__.values()]
     bootloaders: typing.List[typing.Type[Bootloader]] = [
-        LILO, GRUB2, GRUB, Yaboot, Symlinks]
+        LILO, GRUB2, GRUB, EXTLINUX, Yaboot, Symlinks]
     layouts: typing.List[typing.Type[Layout]] = [
         BlSpecLayout, StdLayout]
     sorts = [MTimeSort, VersionSort]

--- a/ecleankernel/bootloader/extlinux.py
+++ b/ecleankernel/bootloader/extlinux.py
@@ -1,0 +1,11 @@
+# (c) 2024 Boris Staletic <boris.staletic@protonmail.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+from ecleankernel.bootloader.lilo import LILO
+
+
+class EXTLINUX(LILO):
+    name = "extlinux"
+    kernel_re = r"^\s*(:?LINUX|KERNEL)\s+(?P<path>.+)\s*$"
+    def_path = ("/boot/extlinux/extlinux.conf",
+                "/boot/syslinux/syslinux.cfg")


### PR DESCRIPTION
I've only implemented the BIOS/legacy boot + extlinux combination, because that's what I am using.

The current `krenel_re` matches lines like these:

```
    KERENEL /boot/vmlinuz
    LINUX /boot/vmlinuz.old
```

A few things to discuss there:

1. `KERNEL` tells extlinux to guess the format of the kernel image, which is why `LINUX` is preferred  for linux kernels. Do we want to support `KERNEL`?
2. Absolute paths in extlinux are relative to the filesystem containing `extlinux.conf`. If `/boot` is its own partition, then the above line would be `LINUX /vmlinuz.old`. I do not know if eclean-kernel can handle that, even if `extlinux.py` were to implement that logic.
3. Relative paths are relative to `extlinux.conf`. I do not know if eclean-kernel can handle that, even if `extlinux.py` were to implement that logic.

The config file is also a bit more complex than in my implementation:
https://wiki.syslinux.org/wiki/index.php?title=Config#Location_and_name

The previous link also shows the EFI layout.